### PR TITLE
Support asynchronous loading of config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -45,7 +45,8 @@ async function initKnexMigrate(env) {
   }
 
   var environmentVar = commander.env || process.env.NODE_ENV || 'development';
-  var config         = require(env.configPath)[environmentVar];
+  var config = await Promise.resolve(require(env.configPath))
+    .then(environments => environments[environmentVar]);
 
   process.env.NODE_ENV = environmentVar;
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -60,7 +60,70 @@ async function initKnexMigrate(env) {
   return require('../')(knex);
 }
 
-function invoke(env) {
+async function createMigration(env, name, extension) {
+  var name = await initKnexMigrate(env)
+    .then(knexMigrate => knexMigrate.make(name, { extension }));
+
+  success(chalk.green('Created Migration: ' + name));
+}
+
+async function freshInstall(env) {
+  var results = await initKnexMigrate(env)
+    .then(knexMigrate => knexMigrate.install());
+
+  var messages = [];
+
+  results.forEach(function (result) {
+    messages.push(chalk.underline(result || 'main'));
+    messages.push(chalk.green('Succeeded'));
+  });
+
+  success(messages.join('\n'));
+}
+
+async function migrateToLatest(env) {
+  var results = await initKnexMigrate(env)
+    .then(knexMigrate => knexMigrate.latest())
+
+  var messages = [];
+
+  results.forEach(function (result) {
+    messages.push(chalk.underline(result[2] || 'main'));
+    if (result[1].length === 0) {
+      messages.push(chalk.cyan('Already up to date'));
+    }
+    messages.push(chalk.green('Batch ' + result[0] + ' run: ' + result[1].length + ' migrations \n' + chalk.cyan(result[1].join('\n'))));
+  });
+
+  success(messages.join('\n'));
+}
+
+async function rollback(env) {
+  var results = await initKnexMigrate(env)
+    .then(knexMigrate => knexMigrate.rollback());
+
+  var messages = [];
+
+  results.forEach(function (result) {
+    messages.push(chalk.underline(result[2] || 'main'));
+
+    if (result[1].length === 0) {
+      success(chalk.cyan('Already at the base migration'));
+    }
+    success(chalk.green('Batch ' + result[0] + ' rolled back: ' + result[1].length + ' migrations \n') + chalk.cyan(result[1].join('\n')));
+  });
+
+  success(messages.join('\n'));
+}
+
+async function displayCurrentVersion(env) {
+  var version = await initKnexMigrate(env)
+    .then(knexMigrate => knexMigrate.currentVersion());
+
+  success(chalk.green('Current Version: ') + chalk.blue(version));
+}
+
+async function invoke(env) {
 
   var pending, filetypes = ['js', 'coffee'];
 
@@ -78,87 +141,47 @@ function invoke(env) {
     .command('migrate:make <name>')
     .description('       Create a named migration file.')
     .option('-x [' + filetypes.join('|') + ']', 'Specify the stub extension (default js)')
-    .action(function(name) {
+    .action(async function(name) {
       var ext = (argv.x || env.configPath.split('.').pop()).toLowerCase();
-      pending = await initKnexMigrate(env);
-      pending = pending.make(name, {extension: ext}).then(function(name) {
-        success(chalk.green('Created Migration: ' + name));
-      }).catch(exit);
+      pending = createMigration(env, name, ext);
     });
 
   commander
     .command('migrate:install')
     .description('        Install a fresh version of the schema.')
     .action(async function() {
-      pending = await initKnexMigrate(env);
-      pending = pending.install().then(function(results) {
-        var messages = [];
-
-        results.forEach(function (result) {
-          messages.push(chalk.underline(result || 'main'));
-          messages.push(chalk.green('Succeeded'));
-        });
-
-        success(messages.join('\n'));
-      }).catch(exit);
+      pending = freshInstall(env);
     });
 
   commander
     .command('migrate:latest')
     .description('        Run all migrations that have not yet been run.')
     .action(async function() {
-      pending = await initKnexMigrate(env);
-      pending = pending.latest().then(function(results) {
-        var messages = [];
-
-        results.forEach(function (result) {
-          messages.push(chalk.underline(result[2] || 'main'));
-          if (result[1].length === 0) {
-            messages.push(chalk.cyan('Already up to date'));
-          }
-          messages.push(chalk.green('Batch ' + result[0] + ' run: ' + result[1].length + ' migrations \n' + chalk.cyan(result[1].join('\n'))));
-        });
-
-        success(messages.join('\n'));
-      }).catch(exit);
+      pending = migrateToLatest(env);
     });
 
   commander
     .command('migrate:rollback')
     .description('        Rollback the last set of migrations performed.')
     .action(async function() {
-      pending = await initKnexMigrate(env);
-      pending = pending.rollback().then(function(results) {
-        var messages = [];
-
-        results.forEach(function (result) {
-          messages.push(chalk.underline(result[2] || 'main'));
-
-          if (result[1].length === 0) {
-            success(chalk.cyan('Already at the base migration'));
-          }
-          success(chalk.green('Batch ' + result[0] + ' rolled back: ' + result[1].length + ' migrations \n') + chalk.cyan(result[1].join('\n')));
-        });
-
-        success(messages.join('\n'));
-      }).catch(exit);
+      pending = rollback(env);
     });
 
   commander
     .command('migrate:currentVersion')
     .description('       View the current version for the migration.')
-    .action(async function () {
-      pending = await initKnexMigrate(env);
-      pending = pending.currentVersion().then(function(version) {
-        success(chalk.green('Current Version: ') + chalk.blue(version));
-      }).catch(exit);
+    .action(async function() {
+      pending = displayCurrentVersion(env);
     });
 
   commander.parse(process.argv);
 
-  Promise.resolve(pending).then(function() {
+  try {
+    await pending;
     commander.help();
-  });
+  } catch (err) {
+    exit(err);
+  }
 }
 
 var cli = new Liftoff({


### PR DESCRIPTION
The `Promise.reolve(pending)` approach did not take into account that `pending` would later be overwritten. I had two choices regarding the `pending` variable:

**a**) Add another level to the promise-pyramid
or 
**b**) Refactor each command into its own function

As I have a strong opinion against `Promise` pyramids, the choice was easy to make.